### PR TITLE
Add StreamLifetimeService

### DIFF
--- a/src/Services/Base/IStreamLifetimeService.cs
+++ b/src/Services/Base/IStreamLifetimeService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Arcane.Framework.Services.Base;
+
+/// <summary>
+/// Service to manage the lifetime of a stream runner
+/// </summary>
+public interface IStreamLifetimeService: IDisposable
+{
+    /// <summary>
+    /// Add a signal to listen for to stop the stream
+    /// </summary>
+    /// <param name="posixSignal">POSIX signal</param>
+    /// <returns></returns>
+    void AddStreamTerminationSignal(PosixSignal posixSignal);
+}

--- a/src/Services/StreamLifetimeService.cs
+++ b/src/Services/StreamLifetimeService.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Arcane.Framework.Services.Base;
+using Microsoft.Extensions.Logging;
+
+namespace Arcane.Framework.Services;
+
+/// <summary>
+/// The default implementation of the <see cref="IStreamLifetimeService"/> interface.
+/// Creates a service that terminates the stream in response to the SIGTERM signal.
+/// </summary>
+public class StreamLifetimeService: IStreamLifetimeService
+{
+    private readonly IStreamRunnerService streamRunnerService;
+    private readonly ILogger<StreamLifetimeService> logger;
+    private readonly List<PosixSignalRegistration> registrations = new();
+
+    /// <summary>
+    /// Create a new instance of the <see cref="StreamLifetimeService"/> class and register the signal handler.
+    /// </summary>
+    /// <param name="logger">Logger</param>
+    /// <param name="streamRunnerService">A Stream runner owning a stream to be stopped</param>
+    /// <param name="signal">The signal to be handled, defaults to SIGTERM</param>
+    public StreamLifetimeService(ILogger<StreamLifetimeService> logger,
+        IStreamRunnerService streamRunnerService, PosixSignal signal = PosixSignal.SIGTERM)
+    {
+        this.streamRunnerService = streamRunnerService;
+        this.AddStreamTerminationSignal(signal);
+        this.logger = logger;
+    }
+
+    /// <inheritdoc cref="IStreamLifetimeService.AddStreamTerminationSignal"/>>
+    public void AddStreamTerminationSignal(PosixSignal posixSignal)
+    {
+        this.registrations.Add(PosixSignalRegistration.Create(posixSignal, this.StopStream));
+    }
+
+    private void StopStream(PosixSignalContext context)
+    {
+        context.Cancel = true;
+        this.logger.LogInformation("Received a signal {signal}. Stopping the hosted stream and shutting down application", context.Signal);
+        this.streamRunnerService.StopStream();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        this.Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Allows override object disposal in subclasses.
+    /// </summary>
+    /// <param name="disposing"></param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        foreach (var registration in this.registrations)
+        {
+            registration.Dispose();
+        }
+    }
+}
+

--- a/src/Services/StreamLifetimeService.cs
+++ b/src/Services/StreamLifetimeService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Arcane.Framework.Services.Base;
 using Microsoft.Extensions.Logging;
@@ -10,6 +11,7 @@ namespace Arcane.Framework.Services;
 /// The default implementation of the <see cref="IStreamLifetimeService"/> interface.
 /// Creates a service that terminates the stream in response to the SIGTERM signal.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "Implementation is platform-specific")]
 public class StreamLifetimeService: IStreamLifetimeService
 {
     private readonly IStreamRunnerService streamRunnerService;


### PR DESCRIPTION
Part of #18

## Scope

Implemented:

This PR introduces the `StreamLifetimeService`: a class that contains event handlers that can control StreamRunner lifetime.
In current implementation the `StreamLifetimeService` can only stop the `StreamRunner` in reponce to a POSIX Signal.
Current implementation registers the handler for the SIGTERM signal that terminates `StreamRunner` instance.


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.