### PR TITLE
Add JSON converter helpers

### DIFF
--- a/src/Configuration/SecondsToTimeSpanConverter.cs
+++ b/src/Configuration/SecondsToTimeSpanConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -7,6 +8,7 @@ namespace Arcane.Framework.Configuration;
 /// <summary>
 /// Converts Seconds to/from TimeSpan for StreamContext properties serialization/deserialization
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "Trivial")]
 public class SecondsToTimeSpanConverter: JsonConverter<TimeSpan>
 {
     /// <inheritdoc cref="JsonConverter{T}.Read"/>>

--- a/src/Configuration/SecondsToTimeSpanConverter.cs
+++ b/src/Configuration/SecondsToTimeSpanConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Arcane.Framework.Configuration;
+
+/// <summary>
+/// Converts Seconds to/from TimeSpan for StreamContext properties serialization/deserialization
+/// </summary>
+public class SecondsToTimeSpanConverter: JsonConverter<TimeSpan>
+{
+    /// <inheritdoc cref="JsonConverter{T}.Read"/>>
+    public override TimeSpan Read( ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        TimeSpan.FromSeconds(reader.GetInt64());
+
+    /// <inheritdoc cref="JsonConverter{T}.Write"/>>
+    public override void Write(Utf8JsonWriter writer, TimeSpan timeSpanValue, JsonSerializerOptions options) =>
+        writer.WriteNumberValue(timeSpanValue.TotalSeconds);
+}

--- a/src/Configuration/UnixTimeConverter.cs
+++ b/src/Configuration/UnixTimeConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -7,6 +8,7 @@ namespace Arcane.Framework.Configuration;
 /// <summary>
 /// Converts Unix time to/from DateTimeOffset for StreamContext properties serialization/deserialization
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "Trivial")]
 public class UnixTimeConverter: JsonConverter<DateTimeOffset>
 {
 

--- a/src/Configuration/UnixTimeConverter.cs
+++ b/src/Configuration/UnixTimeConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Arcane.Framework.Configuration;
+
+/// <summary>
+/// Converts Unix time to/from DateTimeOffset for StreamContext properties serialization/deserialization
+/// </summary>
+public class UnixTimeConverter: JsonConverter<DateTimeOffset>
+{
+
+    /// <inheritdoc cref="JsonConverter{T}.Read"/>>
+    public override DateTimeOffset Read( ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64());
+
+    /// <inheritdoc cref="JsonConverter{T}.Write"/>>
+    public override void Write(Utf8JsonWriter writer, DateTimeOffset dateTimeValue, JsonSerializerOptions options) =>
+        writer.WriteNumberValue(dateTimeValue.ToUnixTimeMilliseconds());
+}

--- a/src/Providers/StreamContext.cs
+++ b/src/Providers/StreamContext.cs
@@ -5,13 +5,13 @@ using Arcane.Framework.Services.Base;
 using Microsoft.Extensions.DependencyInjection;
 using Snd.Sdk.Hosting;
 
-namespace Arcane.Framework.Providers.StreamContext;
+namespace Arcane.Framework.Providers;
 
 /// <summary>
 /// Provider for the stream context
 /// </summary>
 [ExcludeFromCodeCoverage(Justification = "Trivial")]
-public static class StreamContextProvider
+public static class StreamContext
 {
     private static JsonSerializerOptions DeFaultOptions => new() { PropertyNameCaseInsensitive = true };
 


### PR DESCRIPTION
Part of  #18

## Scope

Implemented:
- Added required JSON converters for serialization/deserialization of stream resources in the runner

Additional changes:
- `StreamContextProvider` was moved to one level up

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.