### PR TITLE
Add Arcane hosting extensions

### DIFF
--- a/src/Arcane.Framework.csproj
+++ b/src/Arcane.Framework.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SnD.Sdk" Version="1.0.8"/>
+        <PackageReference Include="SnD.Sdk" Version="1.1.0"/>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5"/>
         <PackageReference Include="Parquet.Net" Version="3.9.1"/>
         <PackageReference Include="Microsoft.OpenApi" Version="1.6.6"/>

--- a/src/Providers/Hosting/HostBuilderExtensions.cs
+++ b/src/Providers/Hosting/HostBuilderExtensions.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using Akka.Hosting;
+using Arcane.Framework.Services;
+using Arcane.Framework.Services.Base;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Snd.Sdk.ActorProviders;
+using Snd.Sdk.Kubernetes.Providers;
+
+namespace Arcane.Framework.Providers.Hosting;
+
+/// <summary>
+/// Extension methods for building the console streaming host.
+/// </summary>
+public static class HostBuilderExtensions
+{
+    /// <summary>
+    /// Adds the required services for the streaming host.
+    /// </summary>
+    /// <param name="builder">IHostBuilder instance</param>
+    /// <param name="addStreamGraphBuilder">The function that adds the stream graph builder to the services collection.</param>
+    /// <param name="addStreamRunnerService">
+    /// The function that adds the stream runner service to the services collection.
+    /// This parameter is optional. If omitted, the default implementation will be used.
+    /// </param>
+    /// <param name="addStreamLifetimeService">
+    /// The function that adds the stream lifetime service to the services collection.
+    /// This parameter is optional. If omitted, the default implementation will be used.
+    /// </param>
+    /// <param name="configureActorSystem">
+    /// The function that provides the custom configuration for the actor system.
+    /// This parameter is optional. If omitted, the actor system will be configured with default settings provided by the SnD.Sdk library.
+    /// </param>
+    /// <returns>Configured IHostBuilder instance</returns>
+    public static IHostBuilder ConfigureRequiredServices(this IHostBuilder builder,
+        Func<IServiceCollection, IServiceCollection> addStreamGraphBuilder,
+        Func<IServiceProvider, IStreamRunnerService> addStreamRunnerService = null,
+        Func<IServiceProvider, IStreamLifetimeService> addStreamLifetimeService = null,
+        Func<HostBuilderContext, StreamingHostBuilderContext, Action<AkkaConfigurationBuilder>> configureActorSystem = null
+    )
+    {
+        return builder.ConfigureServices((HostBuilderContext, services) =>
+        {
+            addStreamGraphBuilder(services);
+            services.AddKubernetes()
+                .AddServiceWithOptionalFactory<IStreamRunnerService, StreamRunnerService>(addStreamRunnerService)
+                .AddServiceWithOptionalFactory<IStreamLifetimeService, StreamLifetimeService>(addStreamLifetimeService)
+                .AddLocalActorSystem(configureActorSystem?.Invoke(HostBuilderContext, StreamingHostBuilderContext.FromEnvironment()));
+        });
+    }
+
+    /// <summary>
+    /// Allows to configure additional services for the streaming host (metrics, logging, storage writers etc.).
+    /// </summary>
+    /// <param name="builder">IHostBuilder instance</param>
+    /// <param name="configureAdditionalServices">The function that adds services to the services collection.</param>
+    /// <returns>Configured IHostBuilder instance</returns>
+    public static IHostBuilder ConfigureAdditionalServices(this IHostBuilder builder,
+        Action<IServiceCollection, StreamingHostBuilderContext> configureAdditionalServices)
+    {
+        return builder.ConfigureServices((_, services) =>
+        {
+            configureAdditionalServices.Invoke(services, StreamingHostBuilderContext.FromEnvironment());
+        });
+    }
+
+    /// <summary>
+    /// This method adds the untyped stream graph builder to the services collection.
+    /// Untyped stream graph builder is used when the stream context is not known at compile time.
+    /// In this case the implementation of the stream graph builder should contain the logic for determining the stream context type.
+    /// </summary>
+    /// <param name="services">Services collection.</param>
+    /// <param name="provideStreamContext">The factory function that provides the stream context instance.</param>
+    /// <typeparam name="TStreamGraphBuilder">The stream graph builder type.</typeparam>
+    /// <returns>Services collection</returns>
+    public static IServiceCollection AddStreamGraphBuilder<TStreamGraphBuilder>(this IServiceCollection services,
+        Func<StreamingHostBuilderContext, IStreamContext> provideStreamContext)
+        where  TStreamGraphBuilder : class, IStreamGraphBuilder<IStreamContext>
+        {
+            var context = new StreamingHostBuilderContext();
+            services.AddSingleton<IStreamGraphBuilder<IStreamContext>, TStreamGraphBuilder>();
+            services.AddSingleton<IStreamStatusService, StreamStatusService>();
+            services.AddSingleton(_ => provideStreamContext(context));
+            return services;
+        }
+
+    /// <summary>
+    /// This method adds the typed stream graph builder to the services collection.
+    /// The typed stream graph builder is used when the stream context type is known at compile time.
+    /// I's preferable to use this method when possible.
+    /// </summary>
+    /// <param name="services">Services collection.</param>
+    /// <typeparam name="TStreamContext">The stream context type</typeparam>
+    /// <typeparam name="TStreamGraphBuilder">The stream graph builder type.</typeparam>
+    /// <returns></returns>
+    public static IServiceCollection AddStreamGraphBuilder<TStreamGraphBuilder, TStreamContext>(this IServiceCollection services)
+        where TStreamContext : class, IStreamContext, IStreamContextWriter, new() where TStreamGraphBuilder : class, IStreamGraphBuilder<TStreamContext>
+        {
+            services.AddSingleton<IStreamGraphBuilder<TStreamContext>, TStreamGraphBuilder>();
+            services.AddSingleton<IStreamStatusService, StreamStatusService>();
+            services.AddStreamContext<TStreamContext>();
+            return services;
+        }
+
+    private static IServiceCollection AddServiceWithOptionalFactory<TService, TImplementation>(this IServiceCollection services, Func<IServiceProvider, TService> factory = null)
+        where TService : class where TImplementation : class, TService
+    {
+        if (factory != null)
+        {
+            services.AddSingleton(factory);
+        }
+        else
+        {
+            services.AddSingleton<TService, TImplementation>();
+        }
+        return services;
+    }
+}

--- a/src/Providers/Hosting/HostBuilderExtensions.cs
+++ b/src/Providers/Hosting/HostBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Akka.Hosting;
 using Arcane.Framework.Services;
 using Arcane.Framework.Services.Base;
@@ -32,6 +33,7 @@ public static class HostBuilderExtensions
     /// This parameter is optional. If omitted, the actor system will be configured with default settings provided by the SnD.Sdk library.
     /// </param>
     /// <returns>Configured IHostBuilder instance</returns>
+    [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public static IHostBuilder ConfigureRequiredServices(this IHostBuilder builder,
         Func<IServiceCollection, IServiceCollection> addStreamGraphBuilder,
         Func<IServiceProvider, IStreamRunnerService> addStreamRunnerService = null,
@@ -55,6 +57,7 @@ public static class HostBuilderExtensions
     /// <param name="builder">IHostBuilder instance</param>
     /// <param name="configureAdditionalServices">The function that adds services to the services collection.</param>
     /// <returns>Configured IHostBuilder instance</returns>
+    [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public static IHostBuilder ConfigureAdditionalServices(this IHostBuilder builder,
         Action<IServiceCollection, StreamingHostBuilderContext> configureAdditionalServices)
     {
@@ -73,6 +76,7 @@ public static class HostBuilderExtensions
     /// <param name="provideStreamContext">The factory function that provides the stream context instance.</param>
     /// <typeparam name="TStreamGraphBuilder">The stream graph builder type.</typeparam>
     /// <returns>Services collection</returns>
+    [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public static IServiceCollection AddStreamGraphBuilder<TStreamGraphBuilder>(this IServiceCollection services,
         Func<StreamingHostBuilderContext, IStreamContext> provideStreamContext)
         where  TStreamGraphBuilder : class, IStreamGraphBuilder<IStreamContext>
@@ -93,6 +97,7 @@ public static class HostBuilderExtensions
     /// <typeparam name="TStreamContext">The stream context type</typeparam>
     /// <typeparam name="TStreamGraphBuilder">The stream graph builder type.</typeparam>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public static IServiceCollection AddStreamGraphBuilder<TStreamGraphBuilder, TStreamContext>(this IServiceCollection services)
         where TStreamContext : class, IStreamContext, IStreamContextWriter, new() where TStreamGraphBuilder : class, IStreamGraphBuilder<TStreamContext>
         {
@@ -102,6 +107,7 @@ public static class HostBuilderExtensions
             return services;
         }
 
+    [ExcludeFromCodeCoverage(Justification = "Trivial")]
     private static IServiceCollection AddServiceWithOptionalFactory<TService, TImplementation>(this IServiceCollection services, Func<IServiceProvider, TService> factory = null)
         where TService : class where TImplementation : class, TService
     {

--- a/src/Providers/Hosting/StreamHostBuilderContext.cs
+++ b/src/Providers/Hosting/StreamHostBuilderContext.cs
@@ -1,10 +1,12 @@
-﻿using Snd.Sdk.Hosting;
+﻿using System.Diagnostics.CodeAnalysis;
+using Snd.Sdk.Hosting;
 
 namespace Arcane.Framework.Providers.Hosting;
 
 /// <summary>
 /// Class that provides context for the stream host builder and data for the stream context
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "Model")]
 public class StreamingHostBuilderContext
 {
     /// <summary>

--- a/src/Providers/Hosting/StreamHostBuilderContext.cs
+++ b/src/Providers/Hosting/StreamHostBuilderContext.cs
@@ -1,0 +1,36 @@
+﻿using Snd.Sdk.Hosting;
+
+namespace Arcane.Framework.Providers.Hosting;
+
+/// <summary>
+/// Class that provides context for the stream host builder and data for the stream context
+/// </summary>
+public class StreamingHostBuilderContext
+{
+    /// <summary>
+    /// Id of the stream
+    /// </summary>
+    public string StreamId { get; } = EnvironmentExtensions.GetAssemblyEnvironmentVariable("STREAM_ID");
+
+    /// <summary>
+    /// True if stream is running in backfill (full reload) mode
+    /// </summary>
+    public bool IsBackfilling { get; } = EnvironmentExtensions
+        .GetAssemblyEnvironmentVariable("BACKFILL")
+        .Equals("true", System.StringComparison.InvariantCultureIgnoreCase);
+
+    /// <summary>
+    /// Kind of the custom resource that manages the stream
+    /// </summary>
+    public string StreamKind { get; } = (EnvironmentExtensions.GetAssemblyEnvironmentVariable("STREAM_KIND"));
+
+    /// <summary>
+    /// Application name for the stream for observability services
+    /// </summary>
+    public string ApplicationName => $"Arcane.Stream.{this.StreamKind}";
+
+    /// <summary>
+    /// Creates a new instance of the StreamingHostBuilderContext with values from the environment variables
+    /// </summary>
+    public static StreamingHostBuilderContext FromEnvironment() => new();
+}


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-framework/issues/18

## Scope

- Bump the `SnD.Sdk` package to version 1.1.0
- Add the `HostBuilderExtensions` class to simplify ServiceCollection building for the Arcane.Framework-based stream plugins.
- Add the `StreamingHostBuilderContext` class for providing context to `IHostBuilder` extension methods

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.