### PR TITLE
Do not reset console output if datadog logging is configured

### DIFF
--- a/src/Providers/Hosting/HostBuilderExtensions.cs
+++ b/src/Providers/Hosting/HostBuilderExtensions.cs
@@ -29,11 +29,15 @@ public static class HostBuilderExtensions
     /// <param name="builder">IHostBuilder instance</param>
     /// <returns>Configured IHostBuilder instance</returns>
     [ExcludeFromCodeCoverage(Justification = "Trivial")]
-    public static IHostBuilder AddDatadogLogging(this IHostBuilder builder)
+    public static IHostBuilder AddDatadogLogging(this IHostBuilder builder, Action<HostBuilderContext, IServiceProvider, LoggerConfiguration> configureLogger = null)
     {
         var context = StreamingHostBuilderContext.FromEnvironment();
-        return builder.AddSerilogLogger(context.ApplicationName, (_, _, loggerConfiguration) =>
-            loggerConfiguration.Enrich.WithProperty("streamId", context.StreamId).AddDatadog()
+        return builder.AddSerilogLogger(context.ApplicationName,
+            (hostBuilderContext, applicationName, loggerConfiguration) =>
+            {
+                configureLogger?.Invoke(hostBuilderContext, applicationName, loggerConfiguration);
+                loggerConfiguration.Enrich.WithProperty("streamId", context.StreamId).AddDatadog();
+            }
         );
     }
 

--- a/src/Providers/Hosting/HostBuilderExtensions.cs
+++ b/src/Providers/Hosting/HostBuilderExtensions.cs
@@ -22,11 +22,11 @@ namespace Arcane.Framework.Providers.Hosting;
 /// </summary>
 public static class HostBuilderExtensions
 {
-
     /// <summary>
     /// Add the default logging configuration to the streaming host builder.
     /// </summary>
     /// <param name="builder">IHostBuilder instance</param>
+    /// <param name="configureLogger">Optional logger configuration callback.</param>
     /// <returns>Configured IHostBuilder instance</returns>
     [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public static IHostBuilder AddDatadogLogging(this IHostBuilder builder, Action<HostBuilderContext, IServiceProvider, LoggerConfiguration> configureLogger = null)


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-operator/issues/40

## Scope

Implemented:
- Added optional logger configuration callback.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.