### PR TITLE
Explicit default prefix for environment variables

### DIFF
--- a/src/Providers/Hosting/HostBuilderExtensions.cs
+++ b/src/Providers/Hosting/HostBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Arcane.Framework.Providers.Hosting;
 /// </summary>
 public static class HostBuilderExtensions
 {
-    private static string EnvPrefix => "SND.SDK__";
+    private const string ENV_PREFIX = "STREAMCONTEXT__";
 
     /// <summary>
     /// Add the default logging configuration to the streaming host builder.
@@ -34,7 +34,7 @@ public static class HostBuilderExtensions
     [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public static IHostBuilder AddDatadogLogging(this IHostBuilder builder, Action<HostBuilderContext, IServiceProvider, LoggerConfiguration> configureLogger = null, string envPrefix = null)
     {
-        var context = StreamingHostBuilderContext.FromEnvironment(envPrefix ?? EnvPrefix);
+        var context = StreamingHostBuilderContext.FromEnvironment(envPrefix ?? ENV_PREFIX);
         return builder.AddSerilogLogger(context.ApplicationName,
             (hostBuilderContext, applicationName, loggerConfiguration) =>
             {
@@ -78,7 +78,7 @@ public static class HostBuilderExtensions
             services.AddKubernetes()
                 .AddServiceWithOptionalFactory<IStreamRunnerService, StreamRunnerService>(addStreamRunnerService)
                 .AddServiceWithOptionalFactory<IStreamLifetimeService, StreamLifetimeService>(addStreamLifetimeService)
-                .AddLocalActorSystem(configureActorSystem?.Invoke(HostBuilderContext, StreamingHostBuilderContext.FromEnvironment(envPrefix ?? EnvPrefix)));
+                .AddLocalActorSystem(configureActorSystem?.Invoke(HostBuilderContext, StreamingHostBuilderContext.FromEnvironment(envPrefix ?? ENV_PREFIX)));
         });
     }
 
@@ -95,7 +95,7 @@ public static class HostBuilderExtensions
     {
         return builder.ConfigureServices((_, services) =>
         {
-            configureAdditionalServices.Invoke(services, StreamingHostBuilderContext.FromEnvironment(envPrefix ?? EnvPrefix));
+            configureAdditionalServices.Invoke(services, StreamingHostBuilderContext.FromEnvironment(envPrefix ?? ENV_PREFIX));
         });
     }
 
@@ -114,7 +114,7 @@ public static class HostBuilderExtensions
         Func<StreamingHostBuilderContext, IStreamContext> provideStreamContext, string envPrefix = null)
         where  TStreamGraphBuilder : class, IStreamGraphBuilder<IStreamContext>
     {
-        var context = StreamingHostBuilderContext.FromEnvironment(envPrefix ?? EnvPrefix);
+        var context = StreamingHostBuilderContext.FromEnvironment(envPrefix ?? ENV_PREFIX);
             services.AddSingleton<IStreamGraphBuilder<IStreamContext>, TStreamGraphBuilder>();
             services.AddSingleton<IStreamStatusService, StreamStatusService>();
             services.AddSingleton(_ => provideStreamContext(context));

--- a/src/Providers/Hosting/HostBuilderExtensions.cs
+++ b/src/Providers/Hosting/HostBuilderExtensions.cs
@@ -22,16 +22,19 @@ namespace Arcane.Framework.Providers.Hosting;
 /// </summary>
 public static class HostBuilderExtensions
 {
+    private static string EnvPrefix => "SND_SDK__";
+
     /// <summary>
     /// Add the default logging configuration to the streaming host builder.
     /// </summary>
     /// <param name="builder">IHostBuilder instance</param>
     /// <param name="configureLogger">Optional logger configuration callback.</param>
+    /// <param name="envPrefix">StreamingHostBuilderContext environment variables prefix</param>
     /// <returns>Configured IHostBuilder instance</returns>
     [ExcludeFromCodeCoverage(Justification = "Trivial")]
-    public static IHostBuilder AddDatadogLogging(this IHostBuilder builder, Action<HostBuilderContext, IServiceProvider, LoggerConfiguration> configureLogger = null)
+    public static IHostBuilder AddDatadogLogging(this IHostBuilder builder, Action<HostBuilderContext, IServiceProvider, LoggerConfiguration> configureLogger = null, string envPrefix = null)
     {
-        var context = StreamingHostBuilderContext.FromEnvironment();
+        var context = StreamingHostBuilderContext.FromEnvironment(envPrefix ?? EnvPrefix);
         return builder.AddSerilogLogger(context.ApplicationName,
             (hostBuilderContext, applicationName, loggerConfiguration) =>
             {
@@ -58,13 +61,15 @@ public static class HostBuilderExtensions
     /// The function that provides the custom configuration for the actor system.
     /// This parameter is optional. If omitted, the actor system will be configured with default settings provided by the SnD.Sdk library.
     /// </param>
+    /// <param name="envPrefix">StreamingHostBuilderContext environment variables prefix</param>
     /// <returns>Configured IHostBuilder instance</returns>
     [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public static IHostBuilder ConfigureRequiredServices(this IHostBuilder builder,
         Func<IServiceCollection, IServiceCollection> addStreamGraphBuilder,
         Func<IServiceProvider, IStreamRunnerService> addStreamRunnerService = null,
         Func<IServiceProvider, IStreamLifetimeService> addStreamLifetimeService = null,
-        Func<HostBuilderContext, StreamingHostBuilderContext, Action<AkkaConfigurationBuilder>> configureActorSystem = null
+        Func<HostBuilderContext, StreamingHostBuilderContext, Action<AkkaConfigurationBuilder>> configureActorSystem = null,
+        string envPrefix = null
     )
     {
         return builder.ConfigureServices((HostBuilderContext, services) =>
@@ -73,7 +78,7 @@ public static class HostBuilderExtensions
             services.AddKubernetes()
                 .AddServiceWithOptionalFactory<IStreamRunnerService, StreamRunnerService>(addStreamRunnerService)
                 .AddServiceWithOptionalFactory<IStreamLifetimeService, StreamLifetimeService>(addStreamLifetimeService)
-                .AddLocalActorSystem(configureActorSystem?.Invoke(HostBuilderContext, StreamingHostBuilderContext.FromEnvironment()));
+                .AddLocalActorSystem(configureActorSystem?.Invoke(HostBuilderContext, StreamingHostBuilderContext.FromEnvironment(envPrefix ?? EnvPrefix)));
         });
     }
 
@@ -82,14 +87,15 @@ public static class HostBuilderExtensions
     /// </summary>
     /// <param name="builder">IHostBuilder instance</param>
     /// <param name="configureAdditionalServices">The function that adds services to the services collection.</param>
+    /// <param name="envPrefix">StreamingHostBuilderContext environment variables prefix</param>
     /// <returns>Configured IHostBuilder instance</returns>
     [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public static IHostBuilder ConfigureAdditionalServices(this IHostBuilder builder,
-        Action<IServiceCollection, StreamingHostBuilderContext> configureAdditionalServices)
+        Action<IServiceCollection, StreamingHostBuilderContext> configureAdditionalServices, string envPrefix = null)
     {
         return builder.ConfigureServices((_, services) =>
         {
-            configureAdditionalServices.Invoke(services, StreamingHostBuilderContext.FromEnvironment());
+            configureAdditionalServices.Invoke(services, StreamingHostBuilderContext.FromEnvironment(envPrefix ?? EnvPrefix));
         });
     }
 
@@ -100,14 +106,15 @@ public static class HostBuilderExtensions
     /// </summary>
     /// <param name="services">Services collection.</param>
     /// <param name="provideStreamContext">The factory function that provides the stream context instance.</param>
+    /// <param name="envPrefix">StreamingHostBuilderContext environment variables prefix</param>
     /// <typeparam name="TStreamGraphBuilder">The stream graph builder type.</typeparam>
     /// <returns>Services collection</returns>
     [ExcludeFromCodeCoverage(Justification = "Trivial")]
     public static IServiceCollection AddStreamGraphBuilder<TStreamGraphBuilder>(this IServiceCollection services,
-        Func<StreamingHostBuilderContext, IStreamContext> provideStreamContext)
+        Func<StreamingHostBuilderContext, IStreamContext> provideStreamContext, string envPrefix = null)
         where  TStreamGraphBuilder : class, IStreamGraphBuilder<IStreamContext>
-        {
-            var context = new StreamingHostBuilderContext();
+    {
+        var context = StreamingHostBuilderContext.FromEnvironment(envPrefix ?? EnvPrefix);
             services.AddSingleton<IStreamGraphBuilder<IStreamContext>, TStreamGraphBuilder>();
             services.AddSingleton<IStreamStatusService, StreamStatusService>();
             services.AddSingleton(_ => provideStreamContext(context));

--- a/src/Providers/Hosting/HostBuilderExtensions.cs
+++ b/src/Providers/Hosting/HostBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Arcane.Framework.Providers.Hosting;
 /// </summary>
 public static class HostBuilderExtensions
 {
-    private static string EnvPrefix => "SND_SDK__";
+    private static string EnvPrefix => "SND.SDK__";
 
     /// <summary>
     /// Add the default logging configuration to the streaming host builder.

--- a/src/Providers/Hosting/StreamHostBuilderContext.cs
+++ b/src/Providers/Hosting/StreamHostBuilderContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using Snd.Sdk.Hosting;
 
 namespace Arcane.Framework.Providers.Hosting;
 
@@ -11,7 +10,7 @@ namespace Arcane.Framework.Providers.Hosting;
 public class StreamingHostBuilderContext {
     private StreamingHostBuilderContext(string prefix)
     {
-        var environmentPrefix = prefix ?? EnvironmentExtensions.GetAssemblyVariablePrefix();
+        var environmentPrefix = prefix ?? throw new ArgumentNullException(nameof(prefix));
         this.StreamId = Environment.GetEnvironmentVariable($"{environmentPrefix}STREAM_ID");
 
         var isBackfilling = Environment.GetEnvironmentVariable($"{environmentPrefix}BACKFILL") ??

--- a/src/Providers/Hosting/StreamHostBuilderContext.cs
+++ b/src/Providers/Hosting/StreamHostBuilderContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Snd.Sdk.Hosting;
 
 namespace Arcane.Framework.Providers.Hosting;
@@ -7,17 +8,16 @@ namespace Arcane.Framework.Providers.Hosting;
 /// Class that provides context for the stream host builder and data for the stream context
 /// </summary>
 [ExcludeFromCodeCoverage(Justification = "Model")]
-public class StreamingHostBuilderContext
-{
+public class StreamingHostBuilderContext {
     private StreamingHostBuilderContext(string prefix)
     {
         var environmentPrefix = prefix ?? EnvironmentExtensions.GetAssemblyVariablePrefix();
-        this.StreamId = EnvironmentExtensions.GetAssemblyEnvironmentVariable($"{environmentPrefix}STREAM_ID");
+        this.StreamId = Environment.GetEnvironmentVariable($"{environmentPrefix}STREAM_ID");
 
-        this.IsBackfilling = EnvironmentExtensions.GetAssemblyEnvironmentVariable($"{environmentPrefix}BACKFILL")
+        this.IsBackfilling = Environment.GetEnvironmentVariable($"{environmentPrefix}BACKFILL")
             .Equals("true", System.StringComparison.InvariantCultureIgnoreCase);
 
-        this.StreamKind = EnvironmentExtensions.GetAssemblyEnvironmentVariable($"{environmentPrefix}STREAM_KIND");
+        this.StreamKind = Environment.GetEnvironmentVariable($"{environmentPrefix}STREAM_KIND");
     }
 
 

--- a/src/Providers/Hosting/StreamHostBuilderContext.cs
+++ b/src/Providers/Hosting/StreamHostBuilderContext.cs
@@ -9,22 +9,32 @@ namespace Arcane.Framework.Providers.Hosting;
 [ExcludeFromCodeCoverage(Justification = "Model")]
 public class StreamingHostBuilderContext
 {
+    private StreamingHostBuilderContext(string prefix)
+    {
+        var environmentPrefix = prefix ?? EnvironmentExtensions.GetAssemblyVariablePrefix();
+        this.StreamId = EnvironmentExtensions.GetAssemblyEnvironmentVariable($"{environmentPrefix}STREAM_ID");
+
+        this.IsBackfilling = EnvironmentExtensions.GetAssemblyEnvironmentVariable($"{environmentPrefix}BACKFILL")
+            .Equals("true", System.StringComparison.InvariantCultureIgnoreCase);
+
+        this.StreamKind = EnvironmentExtensions.GetAssemblyEnvironmentVariable($"{environmentPrefix}STREAM_KIND");
+    }
+
+
     /// <summary>
     /// Id of the stream
     /// </summary>
-    public string StreamId { get; } = EnvironmentExtensions.GetAssemblyEnvironmentVariable("STREAM_ID");
+    public string StreamId { get; }
 
     /// <summary>
     /// True if stream is running in backfill (full reload) mode
     /// </summary>
-    public bool IsBackfilling { get; } = EnvironmentExtensions
-        .GetAssemblyEnvironmentVariable("BACKFILL")
-        .Equals("true", System.StringComparison.InvariantCultureIgnoreCase);
+    public bool IsBackfilling { get;  }
 
     /// <summary>
     /// Kind of the custom resource that manages the stream
     /// </summary>
-    public string StreamKind { get; } = (EnvironmentExtensions.GetAssemblyEnvironmentVariable("STREAM_KIND"));
+    public string StreamKind { get; }
 
     /// <summary>
     /// Application name for the stream for observability services
@@ -34,5 +44,5 @@ public class StreamingHostBuilderContext
     /// <summary>
     /// Creates a new instance of the StreamingHostBuilderContext with values from the environment variables
     /// </summary>
-    public static StreamingHostBuilderContext FromEnvironment() => new();
+    public static StreamingHostBuilderContext FromEnvironment(string prefix) => new(prefix);
 }

--- a/src/Providers/Hosting/StreamHostBuilderContext.cs
+++ b/src/Providers/Hosting/StreamHostBuilderContext.cs
@@ -14,9 +14,10 @@ public class StreamingHostBuilderContext {
         var environmentPrefix = prefix ?? EnvironmentExtensions.GetAssemblyVariablePrefix();
         this.StreamId = Environment.GetEnvironmentVariable($"{environmentPrefix}STREAM_ID");
 
-        this.IsBackfilling = Environment.GetEnvironmentVariable($"{environmentPrefix}BACKFILL")
-            .Equals("true", System.StringComparison.InvariantCultureIgnoreCase);
+        var isBackfilling = Environment.GetEnvironmentVariable($"{environmentPrefix}BACKFILL") ??
+                             throw new ArgumentNullException($"{environmentPrefix}BACKFILL");
 
+        this.IsBackfilling = isBackfilling.Equals("true", StringComparison.InvariantCultureIgnoreCase);
         this.StreamKind = Environment.GetEnvironmentVariable($"{environmentPrefix}STREAM_KIND");
     }
 


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-operator/issues/40

## Scope

Implemented:
- Add ability to override the context environment variables prefix

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.