### PR TITLE
Fix incorrect start offset

### DIFF
--- a/src/Sources/RestApi/RestApiSource.cs
+++ b/src/Sources/RestApi/RestApiSource.cs
@@ -437,6 +437,7 @@ public class RestApiSource : GraphStage<SourceShape<JsonElement>>, IParquetSourc
 
                     if (maybeNextUri.IsEmpty)
                     {
+                        this.currentResponse = null;
                         return Task.FromResult(Option<JsonElement>.None);
                     }
 

--- a/src/Sources/RestApi/RestApiSource.cs
+++ b/src/Sources/RestApi/RestApiSource.cs
@@ -437,7 +437,6 @@ public class RestApiSource : GraphStage<SourceShape<JsonElement>>, IParquetSourc
 
                     if (maybeNextUri.IsEmpty)
                     {
-                        this.currentResponse = null;
                         return Task.FromResult(Option<JsonElement>.None);
                     }
 

--- a/src/Sources/RestApi/Services/PageResolvers/PageOffsetResolver.cs
+++ b/src/Sources/RestApi/Services/PageResolvers/PageOffsetResolver.cs
@@ -35,6 +35,12 @@ public sealed class PageOffsetResolver : PageResolverBase<int?>
         {
             if (!this.GetResponseContent(apiResponse, this.responseBodyPropertyKeyChain).Any())
             {
+                if (this.pagePointer == null)
+                {
+                    this.pagePointer = this.startOffset ?? 0;
+                    return true;
+                }
+
                 this.pagePointer = null;
                 return false;
             }

--- a/src/Sources/RestApi/Services/PageResolvers/PageOffsetResolver.cs
+++ b/src/Sources/RestApi/Services/PageResolvers/PageOffsetResolver.cs
@@ -12,6 +12,7 @@ public sealed class PageOffsetResolver : PageResolverBase<int?>
 {
     private readonly string[] responseBodyPropertyKeyChain;
     private readonly int responseSize;
+    private readonly int? startOffset;
 
     /// <summary>
     /// Page offset resolver for numeric page pointers.
@@ -23,7 +24,8 @@ public sealed class PageOffsetResolver : PageResolverBase<int?>
     {
         this.responseSize = responseSize;
         this.responseBodyPropertyKeyChain = responseBodyPropertyKeyChain;
-        this.pagePointer = startOffset ?? 0;
+        this.startOffset = startOffset;
+        this.pagePointer = this.startOffset ?? 0;
     }
 
     /// <inheritdoc cref="PageResolverBase{TPagePointer}.Next"/>
@@ -47,7 +49,7 @@ public sealed class PageOffsetResolver : PageResolverBase<int?>
             return false;
         }
 
-        this.pagePointer = 0;
+        this.pagePointer = this.startOffset ?? 0;
         return true;
     }
 }


### PR DESCRIPTION
## Scope
When the `PageOffsetResolver` reaches the end of pagination it hangs because it cannot determine the difference between two conditions: when response is empty (means end of pagination) and the source was called first time.

Implemented:
- Additional check to determine if the resolver is in paginated state or was called first time.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.