### PR TITLE
Assign namespaces and members visibility

### DIFF
--- a/src/Arcane.Framework.csproj
+++ b/src/Arcane.Framework.csproj
@@ -30,6 +30,12 @@
         </None>
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Arcane.Framework.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
     <PropertyGroup>
         <PackageId>Arcane.Framework</PackageId>
         <Version>0.0.0</Version>

--- a/src/Contracts/Constants.cs
+++ b/src/Contracts/Constants.cs
@@ -6,7 +6,7 @@ namespace Arcane.Framework.Contracts;
 /// Common container exit codes
 /// </summary>
 [ExcludeFromCodeCoverage(Justification = "Trivial")]
-public static class ExitCodes
+internal static class ExitCodes
 {
     /// <summary>
     /// Job completed successfully

--- a/src/Services/StreamLifetimeService.cs
+++ b/src/Services/StreamLifetimeService.cs
@@ -12,7 +12,7 @@ namespace Arcane.Framework.Services;
 /// Creates a service that terminates the stream in response to the SIGTERM signal.
 /// </summary>
 [ExcludeFromCodeCoverage(Justification = "Implementation is platform-specific")]
-public class StreamLifetimeService: IStreamLifetimeService
+internal class StreamLifetimeService: IStreamLifetimeService
 {
     private readonly IStreamRunnerService streamRunnerService;
     private readonly ILogger<StreamLifetimeService> logger;

--- a/src/Services/StreamRunnerService.cs
+++ b/src/Services/StreamRunnerService.cs
@@ -11,7 +11,7 @@ namespace Arcane.Framework.Services;
 
 /// <inheritdoc/>
 [ExcludeFromCodeCoverage(Justification = "Trivial")]
-public class StreamRunnerService : IStreamRunnerService
+internal class StreamRunnerService : IStreamRunnerService
 
 {
     private readonly IHostApplicationLifetime applicationLifetime;

--- a/src/Sinks/Base/ISchemaBoundSink.cs
+++ b/src/Sinks/Base/ISchemaBoundSink.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using Akka.Streams.Dsl;
+﻿using Akka.Streams.Dsl;
+using Arcane.Framework.Sources.Base;
 
-namespace Arcane.Framework.Sources.Base;
+namespace Arcane.Framework.Sinks.Base;
 
 /// <summary>
 /// Wraps a sink that requires a schema
@@ -9,7 +9,7 @@ namespace Arcane.Framework.Sources.Base;
 /// <typeparam name="TIn">Input element type</typeparam>
 /// <typeparam name="TMat">Type of materialized value</typeparam>
 /// <typeparam name="TSchema">Type of the schema validator</typeparam>
-public interface ISchemaBoundSink<TIn, TMat, TSchema>  where TSchema : ISchemaValidator<TIn>
+public interface ISchemaBoundSink<TIn, out TMat, TSchema>  where TSchema : ISchemaValidator<TIn>
 {
     /// <summary>
     /// Returns a graph builder function that connects a source to the sink

--- a/src/Sinks/Base/ISchemaFreeSink.cs
+++ b/src/Sinks/Base/ISchemaFreeSink.cs
@@ -1,14 +1,13 @@
-using System;
 using Akka.Streams.Dsl;
 
-namespace Arcane.Framework.Sources.Base;
+namespace Arcane.Framework.Sinks.Base;
 
 /// <summary>
 /// Wraps a sink that does not require a schema
 /// </summary>
 /// <typeparam name="TIn">Input element tye</typeparam>
 /// <typeparam name="TMat">Type of materialized value</typeparam>
-public interface ISchemaFreeSink<TIn, TMat>
+public interface ISchemaFreeSink<TIn, out TMat>
 {
     /// <summary>
     /// Returns a graph builder function that connects a source to the sink

--- a/src/Sinks/Extensions/SchemaFreeSourceExtensions.cs
+++ b/src/Sinks/Extensions/SchemaFreeSourceExtensions.cs
@@ -1,3 +1,4 @@
+using Arcane.Framework.Sinks.Base;
 using Arcane.Framework.Sources.Base;
 
 namespace Arcane.Framework.Sinks.Extensions;

--- a/src/Sinks/Parquet/ParquetSink.cs
+++ b/src/Sinks/Parquet/ParquetSink.cs
@@ -7,7 +7,6 @@ using Akka.Actor;
 using Akka.Event;
 using Akka.Streams;
 using Akka.Streams.Stage;
-using Arcane.Framework.Sinks.Parquet;
 using Parquet;
 using Parquet.Data;
 using Snd.Sdk.Storage.Base;
@@ -15,7 +14,7 @@ using Snd.Sdk.Storage.Models;
 using Snd.Sdk.Tasks;
 using ParquetColumn = Parquet.Data.DataColumn;
 
-namespace Arcane.Framework.Sinks;
+namespace Arcane.Framework.Sinks.Parquet;
 
 /// <summary>
 /// Sink that allows writing data to Azure blob in Parquet format.

--- a/src/Sinks/SchemaBoundSink.cs
+++ b/src/Sinks/SchemaBoundSink.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Akka;
-using Akka.Streams.Dsl;
-using Arcane.Framework.Sources;
+﻿using Akka.Streams.Dsl;
+using Arcane.Framework.Sinks.Base;
 using Arcane.Framework.Sources.Base;
 
 namespace Arcane.Framework.Sinks;

--- a/src/Sinks/SchemaFreeSink.cs
+++ b/src/Sinks/SchemaFreeSink.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using Akka.Streams.Dsl;
-using Arcane.Framework.Sources.Base;
+﻿using Akka.Streams.Dsl;
+using Arcane.Framework.Sinks.Base;
 
 namespace Arcane.Framework.Sinks;
 

--- a/src/Sources/Base/ISchemaBoundSource.cs
+++ b/src/Sources/Base/ISchemaBoundSource.cs
@@ -1,5 +1,6 @@
 using System;
 using Akka.Streams.Dsl;
+using Arcane.Framework.Sinks.Base;
 
 namespace Arcane.Framework.Sources.Base;
 

--- a/src/Sources/Base/ISchemaFreeSource.cs
+++ b/src/Sources/Base/ISchemaFreeSource.cs
@@ -1,6 +1,7 @@
 using System;
 using Akka.Streams;
 using Akka.Streams.Dsl;
+using Arcane.Framework.Sinks.Base;
 
 namespace Arcane.Framework.Sources.Base;
 

--- a/src/Sources/CdmChangeFeedSource/Extensions/CsvOperations.cs
+++ b/src/Sources/CdmChangeFeedSource/Extensions/CsvOperations.cs
@@ -7,7 +7,7 @@ namespace Arcane.Framework.Sources.CdmChangeFeedSource.Extensions;
 /// <summary>
 /// Contains operations for parsing CSV files.
 /// </summary>
-public static class CsvOperations
+internal static class CsvOperations
 {
     /// <summary>
     /// Splits a CSV line into a string array, using provided header count and a delimiter.

--- a/src/Sources/CdmChangeFeedSource/Extensions/JsonDocumentOperations.cs
+++ b/src/Sources/CdmChangeFeedSource/Extensions/JsonDocumentOperations.cs
@@ -6,7 +6,7 @@ namespace Arcane.Framework.Sources.CdmChangeFeedSource.Extensions;
 /// <summary>
 /// Contains operations for parsing JSON documents.
 /// </summary>
-public static class JsonDocumentOperations
+internal static class JsonDocumentOperations
 {
     /// <summary>
     /// Get an element from a JSON array

--- a/src/Sources/CdmChangeFeedSource/Extensions/SimpleCdmAttributeExtensions.cs
+++ b/src/Sources/CdmChangeFeedSource/Extensions/SimpleCdmAttributeExtensions.cs
@@ -9,7 +9,7 @@ namespace Arcane.Framework.Sources.CdmChangeFeedSource.Extensions;
 /// <summary>
 /// Extenstion method for SimpleCdmAttribute class
 /// </summary>
-public static class SimpleCdmAttributeExtensions
+internal static class SimpleCdmAttributeExtensions
 {
     /// <summary>
     /// Resolve complex type to list of attributes

--- a/src/Sources/CdmChangeFeedSource/Models/SimpleCdmAttribute.cs
+++ b/src/Sources/CdmChangeFeedSource/Models/SimpleCdmAttribute.cs
@@ -9,7 +9,7 @@ namespace Arcane.Framework.Sources.CdmChangeFeedSource.Models;
 /// <summary>
 /// Represents CDM Change Feed attribute
 /// </summary>
-public class SimpleCdmAttribute
+internal class SimpleCdmAttribute
 {
     private static readonly Dictionary<string, Type> cdmTypeMap = new()
     {

--- a/src/Sources/CdmChangeFeedSource/Models/SimpleCdmEntity.cs
+++ b/src/Sources/CdmChangeFeedSource/Models/SimpleCdmEntity.cs
@@ -10,7 +10,7 @@ namespace Arcane.Framework.Sources.CdmChangeFeedSource.Models;
 /// <summary>
 /// Represents CDM Change Feed entity
 /// </summary>
-public class SimpleCdmEntity
+internal class SimpleCdmEntity
 {
     /// <summary>
     /// Entity name

--- a/src/Sources/Exceptions/SchemaInconsistentException.cs
+++ b/src/Sources/Exceptions/SchemaInconsistentException.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace Arcane.Framework.Sources.Exceptions;
 

--- a/src/Sources/Extensions/GraphStageLogicExtensions.cs
+++ b/src/Sources/Extensions/GraphStageLogicExtensions.cs
@@ -7,7 +7,7 @@ namespace Arcane.Framework.Sources.Extensions;
 /// <summary>
 /// Extensions for GraphStageLogic
 /// </summary>
-public static class GraphStageLogicExtensions
+internal static class GraphStageLogicExtensions
 {
     /// <summary>
     /// Complete stage if StopAfterFullLoad is set to true and source finished full load mode

--- a/src/Sources/Extensions/SchemaFreeSourceExtensions.cs
+++ b/src/Sources/Extensions/SchemaFreeSourceExtensions.cs
@@ -1,4 +1,6 @@
-namespace Arcane.Framework.Sources.Base;
+using Arcane.Framework.Sources.Base;
+
+namespace Arcane.Framework.Sources.Extensions;
 
 /// <summary>
 /// Extension methods for a ISchemaFreeSource interface
@@ -14,9 +16,6 @@ public static class SchemaFreeSourceExtensions
     /// <typeparam name="TMat">Type of materialized value</typeparam>
     /// <typeparam name="TSchema">Type of the schema validator</typeparam>
     /// <returns>Schema bound source</returns>
-    public static ISchemaBoundSource<TOut, TMat, TSchema> WithSchema<TOut, TMat, TSchema>(
-        this ISchemaFreeSource<TOut, TMat> source,
-        TSchema schema) where TSchema : ISchemaValidator<TOut> =>
-        new SchemaBoundSource<TOut, TMat, TSchema>(source,
-            schema);
+    public static ISchemaBoundSource<TOut, TMat, TSchema> WithSchema<TOut, TMat, TSchema>(this ISchemaFreeSource<TOut, TMat> source, TSchema schema) where TSchema : ISchemaValidator<TOut> =>
+        new SchemaBoundSource<TOut, TMat, TSchema>(source, schema);
 }

--- a/src/Sources/Extensions/SinkExtensions.cs
+++ b/src/Sources/Extensions/SinkExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Akka.Streams.Dsl;
 using Arcane.Framework.Sinks;
+using Arcane.Framework.Sinks.Base;
 using Arcane.Framework.Sources.Base;
 
 namespace Arcane.Framework.Sources.Extensions;

--- a/src/Sources/Extensions/SqlServerUtils.cs
+++ b/src/Sources/Extensions/SqlServerUtils.cs
@@ -8,7 +8,7 @@ namespace Arcane.Framework.Sources.Extensions;
 /// <summary>
 /// Utilities for SQL Server database operations.
 /// </summary>
-public static class SqlServerUtils
+internal static class SqlServerUtils
 {
     /// <summary>
     /// Get all columns for the specified table.

--- a/src/Sources/RestApi/Extensions/RestApiExtensions.cs
+++ b/src/Sources/RestApi/Extensions/RestApiExtensions.cs
@@ -12,7 +12,7 @@ namespace Arcane.Framework.Sources.RestApi.Extensions;
 /// <summary>
 /// Contains extension methods for REST API operations.
 /// </summary>
-public static class RestApiExtensions
+internal static class RestApiExtensions
 {
     /// <summary>
     /// Parse OpenApi schema from base64 encoded string.

--- a/src/Sources/RestApi/Models/TemplatedFieldType.cs
+++ b/src/Sources/RestApi/Models/TemplatedFieldType.cs
@@ -1,5 +1,8 @@
 namespace Arcane.Framework.Sources.RestApi.Models;
 
+/// <summary>
+/// Type of the templated field in a REST API request or request body.
+/// </summary>
 public enum TemplatedFieldType
 {
     /// <summary>

--- a/src/Sources/RestApi/RestApiSource.cs
+++ b/src/Sources/RestApi/RestApiSource.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Configuration;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -130,10 +129,7 @@ public class RestApiSource : GraphStage<SourceShape<JsonElement>>, IParquetSourc
     public override SourceShape<JsonElement> Shape { get; }
 
     /// <inheritdoc cref="IParquetSource.GetParquetSchema"/>
-    public Schema GetParquetSchema()
-    {
-        return this.apiSchema.ToParquetSchema();
-    }
+    public Schema GetParquetSchema() => this.apiSchema.ToParquetSchema();
 
     /// <inheritdoc cref="ITaggedSource.GetDefaultTags"/>
     public SourceTags GetDefaultTags()
@@ -302,10 +298,7 @@ public class RestApiSource : GraphStage<SourceShape<JsonElement>>, IParquetSourc
     }
 
     /// <inheritdoc cref="GraphStage{TShape}.CreateLogic"/>
-    protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
-    {
-        return new SourceLogic(this);
-    }
+    protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new SourceLogic(this);
 
     private sealed class SourceLogic : TimerGraphStageLogic, IStopAfterBackfill
     {

--- a/src/Sources/RestApi/Services/AuthenticatedMessageProviders/Base/IRestApiAuthenticatedMessageProvider.cs
+++ b/src/Sources/RestApi/Services/AuthenticatedMessageProviders/Base/IRestApiAuthenticatedMessageProvider.cs
@@ -6,7 +6,7 @@ namespace Arcane.Framework.Sources.RestApi.Services.AuthenticatedMessageProvider
 /// <summary>
 /// Authentication message provider interface for various REST API authentication methods.
 /// </summary>
-public interface IRestApiAuthenticatedMessageProvider
+internal interface IRestApiAuthenticatedMessageProvider
 {
     /// <summary>
     /// Generates authenticated message for the REST API request.

--- a/src/Sources/RestApi/Services/PageResolvers/Base/PageResolverBase.cs
+++ b/src/Sources/RestApi/Services/PageResolvers/Base/PageResolverBase.cs
@@ -11,7 +11,7 @@ namespace Arcane.Framework.Sources.RestApi.Services.PageResolvers.Base;
 /// Base class for page resolvers.
 /// </summary>
 /// <typeparam name="TPagePointer">Type of a page pointer</typeparam>
-public abstract class PageResolverBase<TPagePointer> : IPageResolver
+internal abstract class PageResolverBase<TPagePointer> : IPageResolver
 {
     protected TPagePointer pagePointer;
 

--- a/src/Sources/RestApi/Services/PageResolvers/PageCountingResolver.cs
+++ b/src/Sources/RestApi/Services/PageResolvers/PageCountingResolver.cs
@@ -8,7 +8,7 @@ namespace Arcane.Framework.Sources.RestApi.Services.PageResolvers;
 /// <summary>
 /// Page offset resolver for numeric page pointers.
 /// </summary>
-public sealed class PageCountingResolver : PageResolverBase<int?>
+internal sealed class PageCountingResolver : PageResolverBase<int?>
 {
     private readonly string[] totalPagesPropertyKeyChain;
     private int? totalPages;

--- a/src/Sources/RestApi/Services/PageResolvers/PageNextTokenResolver.cs
+++ b/src/Sources/RestApi/Services/PageResolvers/PageNextTokenResolver.cs
@@ -8,7 +8,7 @@ namespace Arcane.Framework.Sources.RestApi.Services.PageResolvers;
 /// <summary>
 /// Page offset resolver for pages with next link
 /// </summary>
-public class PageNextTokenResolver : PageResolverBase<string>
+internal class PageNextTokenResolver : PageResolverBase<string>
 {
     private readonly string[] nextPageTokenPropertyKeyChain;
 

--- a/src/Sources/RestApi/Services/PageResolvers/PageOffsetResolver.cs
+++ b/src/Sources/RestApi/Services/PageResolvers/PageOffsetResolver.cs
@@ -8,7 +8,7 @@ namespace Arcane.Framework.Sources.RestApi.Services.PageResolvers;
 /// <summary>
 /// Page offset resolver for numeric page pointers.
 /// </summary>
-public sealed class PageOffsetResolver : PageResolverBase<int?>
+internal sealed class PageOffsetResolver : PageResolverBase<int?>
 {
     private readonly string[] responseBodyPropertyKeyChain;
     private readonly int responseSize;

--- a/src/Sources/SchemaBoundSource.cs
+++ b/src/Sources/SchemaBoundSource.cs
@@ -1,7 +1,9 @@
 using System;
 using Akka.Streams;
 using Akka.Streams.Dsl;
+using Arcane.Framework.Sinks.Base;
 using Arcane.Framework.Sources.Base;
+using Arcane.Framework.Sources.Extensions;
 
 namespace Arcane.Framework.Sources;
 
@@ -25,7 +27,8 @@ public class SchemaBoundSource<TOut, TMat, TSchema>: ISchemaBoundSource<TOut, TM
     public TSchema Schema { get; }
 
     /// <inheritdoc />
-    public IArcaneSource<TOut, TMat2> MapMaterializedValue<TMat2>(Func<TMat, TMat2> mapper) => this.source.MapMaterializedValue(mapper);
+    public IArcaneSource<TOut, TMat2> MapMaterializedValue<TMat2>(Func<TMat, TMat2> mapper) =>
+        this.source.MapMaterializedValue(mapper);
 
 
     /// <inheritdoc />
@@ -33,19 +36,19 @@ public class SchemaBoundSource<TOut, TMat, TSchema>: ISchemaBoundSource<TOut, TM
 
 
     /// <inheritdoc />
-    public ISchemaFreeSource<TOut2, TMat> MapSource<TOut2>(Func<Source<TOut, TMat>, Source<TOut2, TMat>> mapper) => this.source.MapSource(mapper);
+    public ISchemaFreeSource<TOut2, TMat> MapSource<TOut2>(Func<Source<TOut, TMat>, Source<TOut2, TMat>> mapper)
+        => this.source.MapSource(mapper);
 
     /// <inheritdoc />
     public IRunnableGraph<TMat2> To<TMat2>(ISchemaFreeSink<TOut, TMat2> sink) => this.source.To(sink);
 
     /// <inheritdoc />
-    public ISchemaFreeSource<TOut2, TMat> Via<TOut2>(IGraph<FlowShape<TOut, TOut2>, TMat> flow)
-    {
-        return this.source.Via(flow);
-    }
+    public ISchemaFreeSource<TOut2, TMat> Via<TOut2>(IGraph<FlowShape<TOut, TOut2>, TMat> flow) =>
+        this.source.Via(flow);
 
     /// <inheritdoc />
-    public ISchemaBoundSource<TOut2, TMat, TNewSchema> Map<TOut2, TNewSchema>(Func<TOut, TOut2> mapper, TNewSchema newSchema) where TNewSchema : ISchemaValidator<TOut2> =>
+    public ISchemaBoundSource<TOut2, TMat, TNewSchema> Map<TOut2, TNewSchema>(Func<TOut, TOut2> mapper, TNewSchema newSchema)
+        where TNewSchema : ISchemaValidator<TOut2> =>
         this.source.Map(mapper).WithSchema(newSchema);
 
     /// <inheritdoc />

--- a/src/Sources/SchemaFreeSource.cs
+++ b/src/Sources/SchemaFreeSource.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Akka.Streams;
 using Akka.Streams.Dsl;
+using Arcane.Framework.Sinks.Base;
 using Arcane.Framework.Sources.Base;
 
 namespace Arcane.Framework.Sources;
@@ -36,8 +37,6 @@ public class SchemaFreeSource<TOut, TMat>: ISchemaFreeSource<TOut, TMat>
         sink.GraphBuilder(this.source);
 
     /// <inheritdoc />
-    public ISchemaFreeSource<TOut2, TMat> Via<TOut2>(IGraph<FlowShape<TOut, TOut2>, TMat> flow)
-    {
-        return new SchemaFreeSource<TOut2, TMat>(this.source.Via(flow));
-    }
+    public ISchemaFreeSource<TOut2, TMat> Via<TOut2>(IGraph<FlowShape<TOut, TOut2>, TMat> flow) =>
+        new SchemaFreeSource<TOut2, TMat>(this.source.Via(flow));
 }

--- a/src/Sources/SqlServer/SqlServerSource.cs
+++ b/src/Sources/SqlServer/SqlServerSource.cs
@@ -31,17 +31,14 @@ public class SqlServerSource : GraphStage<SourceShape<List<DataCell>>>, IParquet
     private readonly int commandTimeout;
     private readonly string connectionString;
     private readonly string schemaName;
-    private readonly string streamKind;
     private readonly string tableName;
 
-    private SqlServerSource(string connectionString, string schemaName, string tableName, string streamKind,
-        int commandTimeout)
+    private SqlServerSource(string connectionString, string schemaName, string tableName, int commandTimeout)
     {
         this.connectionString = connectionString;
         this.schemaName = schemaName;
         this.tableName = tableName;
         this.commandTimeout = commandTimeout;
-        this.streamKind = streamKind;
 
         this.Shape = new SourceShape<List<DataCell>>(this.Out);
     }
@@ -85,20 +82,13 @@ public class SqlServerSource : GraphStage<SourceShape<List<DataCell>>>, IParquet
     /// <param name="connectionString">Sql server connection string</param>
     /// <param name="schemaName">Sql server schema name</param>
     /// <param name="tableName">Table name</param>
-    /// <param name="streamKind">Stream kind</param>
     /// <param name="commandTimeout">Sql server command execution timeout</param>
     [ExcludeFromCodeCoverage(Justification = "Factory method")]
-    public static SqlServerSource Create(string connectionString, string schemaName, string tableName,
-        string streamKind, int commandTimeout = 3600)
-    {
-        return new SqlServerSource(connectionString, schemaName, tableName, streamKind, commandTimeout);
-    }
+    public static SqlServerSource Create(string connectionString, string schemaName, string tableName, int commandTimeout = 3600)
+        => new(connectionString, schemaName, tableName, commandTimeout);
 
     /// <inheritdoc cref="GraphStage{TShape}.CreateLogic"/>
-    protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
-    {
-        return new SourceLogic(this);
-    }
+    protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new SourceLogic(this);
 
     private string GetQuery()
     {

--- a/test/SinkTests/ParquetSinkTests.cs
+++ b/test/SinkTests/ParquetSinkTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Arcane.Framework.Sinks;
+using Arcane.Framework.Sinks.Parquet;
 using Arcane.Framework.Tests.Fixtures;
 using Moq;
 using Parquet.Data;

--- a/test/Sources/SqlServerSourceTests.cs
+++ b/test/Sources/SqlServerSourceTests.cs
@@ -26,7 +26,7 @@ public class SqlServerSourceTests : IClassFixture<ServiceFixture>, IClassFixture
     public async Task Test()
     {
         var result = await Source
-            .FromGraph(SqlServerSource.Create(this.connectionString, "dbo", nameof(SqlServerSourceTests), "test"))
+            .FromGraph(SqlServerSource.Create(this.connectionString, "dbo", nameof(SqlServerSourceTests)))
             .TakeWithin(TimeSpan.FromSeconds(3))
             .RunWith(Sink.Seq<List<DataCell>>(), this.akkaFixture.Materializer);
 
@@ -36,7 +36,7 @@ public class SqlServerSourceTests : IClassFixture<ServiceFixture>, IClassFixture
     [Fact]
     public void GetParquetSchema()
     {
-        var schema = SqlServerSource.Create(this.connectionString, "dbo", nameof(SqlServerSourceTests), "test")
+        var schema = SqlServerSource.Create(this.connectionString, "dbo", nameof(SqlServerSourceTests))
             .GetParquetSchema();
 
         Assert.Equal(2, schema.Fields.Count); // two base columns


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-docs/issues/1

This changes are required to fix some visibility issues in arcane docs website:
1. some classes in wrong namespaces
2. documentation exposed internal implementation details that are not belong to public API

## Scope

Implemented:
- Classes and methods visibility was arranged.
- Using statements and namespaces were organized


## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.