### PR TITLE
Allow using custom properties in Arcane.Framework

### DIFF
--- a/src/Contracts/Logging.cs
+++ b/src/Contracts/Logging.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Text.Json;
+using Serilog;
+using SnD.Sdk.Extensions.Environment.Hosting;
+
+namespace Arcane.Framework.Contracts;
+
+/// <summary>
+/// Logging extension methods for Arcane framework.
+/// </summary>
+public static class Logging
+{
+    /// <summary>
+    /// Allows enriching the logger with properties from the environment.
+    /// </summary>
+    /// <param name="configuration"></param>
+    /// <returns></returns>
+    public static LoggerConfiguration EnrichWithCustomProperties(this LoggerConfiguration configuration)
+    {
+        var loggingProperties = EnvironmentExtensions.GetDomainEnvironmentVariable("LOGGING_PROPERTIES");
+        if (string.IsNullOrEmpty(loggingProperties))
+        {
+            return configuration;
+        }
+
+        var properties = JsonSerializer.Deserialize<Dictionary<string, string>>(loggingProperties);
+        foreach (var (key, value) in properties)
+        {
+            configuration.Enrich.WithProperty(key, value);
+        }
+
+        return configuration;
+    }
+}


### PR DESCRIPTION
## Scope

This PR adds generalized version of https://github.com/SneaksAndData/arcane-stream-blob-storage/pull/26

This is required for uniformed logging in Arcane streams

Follow-up for: https://github.com/SneaksAndData/arcane-stream-blob-storage/issues/27

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.