### PR TITLE
Disallow the empty value for the changeCaptureInteval parameter

### DIFF
--- a/src/Arcane.Framework.csproj
+++ b/src/Arcane.Framework.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>10</LangVersion>
         <RootNamespace>Arcane.Framework</RootNamespace>
         <OutputType>Library</OutputType>

--- a/src/Sources/Base/PollingSource.cs
+++ b/src/Sources/Base/PollingSource.cs
@@ -1,0 +1,31 @@
+using System;
+using Akka.Streams;
+using Akka.Streams.Stage;
+
+namespace Arcane.Framework.Sources.Base;
+
+/// <summary>
+/// Base class for source logic classes for polling sources
+/// </summary>
+public abstract class PollingSourceLogic: TimerGraphStageLogic
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="PollingSourceLogic"/>
+    /// </summary>
+    /// <param name="changeCaptureInterval">Interval for pulling changes in the data source. Should be greater then zero</param>
+    /// <param name="shape">Stage shape</param>
+    /// <exception cref="ArgumentException">Thrown if changeCaptureInterval is less or equal to zero</exception>
+    protected PollingSourceLogic(TimeSpan changeCaptureInterval, Shape shape) : base(shape)
+    {
+        if (changeCaptureInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentException("Change capture interval must be greater than zero.");
+        }
+        ChangeCaptureInterval = changeCaptureInterval;
+    }
+
+    /// <summary>
+    /// Interval for pulling changes in the data source
+    /// </summary>
+    protected TimeSpan ChangeCaptureInterval { get; private init; }
+}

--- a/src/Sources/CdmChangeFeedSource/CdmChangeFeedSource.cs
+++ b/src/Sources/CdmChangeFeedSource/CdmChangeFeedSource.cs
@@ -137,7 +137,7 @@ public class CdmChangeFeedSource : GraphStage<SourceShape<List<DataCell>>>, IPar
         return SimpleCdmEntity.FromJson(schemaData);
     }
 
-    private sealed class SourceLogic : TimerGraphStageLogic, IStopAfterBackfill
+    private sealed class SourceLogic : PollingSourceLogic, IStopAfterBackfill
     {
         private const string TimerKey = "Source";
         private readonly string changeFeedPath;
@@ -150,7 +150,7 @@ public class CdmChangeFeedSource : GraphStage<SourceShape<List<DataCell>>>, IPar
         private DateTimeOffset? maxAvailableTimestamp;
         private DateTimeOffset? nextSchemaUpdateTimestamp;
 
-        public SourceLogic(CdmChangeFeedSource source) : base(source.Shape)
+        public SourceLogic(CdmChangeFeedSource source) : base(source.changeCaptureInterval, source.Shape)
         {
             this.source = source;
             this.changeFeedPath = $"{source.rootPath}/ChangeFeed/{source.entityName}";
@@ -346,7 +346,7 @@ public class CdmChangeFeedSource : GraphStage<SourceShape<List<DataCell>>>, IPar
             {
                 if (!this.CompleteStageAfterFullLoad())
                 {
-                    this.ScheduleOnce(TimerKey, this.source.changeCaptureInterval);
+                    this.ScheduleOnce(TimerKey, this.ChangeCaptureInterval);
                 }
             }
             else

--- a/src/Sources/SqlServer/SqlServerChangeTrackingSource.cs
+++ b/src/Sources/SqlServer/SqlServerChangeTrackingSource.cs
@@ -175,7 +175,7 @@ public class SqlServerChangeTrackingSource : GraphStage<SourceShape<List<DataCel
             .Replace("{MERGE_KEY}", Constants.UPSERT_MERGE_KEY);
     }
 
-    private sealed class SourceLogic : TimerGraphStageLogic, IStopAfterBackfill
+    private sealed class SourceLogic : PollingSourceLogic, IStopAfterBackfill
     {
         private const string TimerKey = "Source";
         private readonly LocalOnlyDecider decider;
@@ -190,7 +190,7 @@ public class SqlServerChangeTrackingSource : GraphStage<SourceShape<List<DataCel
         private Action<Task<Option<List<DataCell>>>> recordsReceived;
         private List<(string columnName, bool isPrimaryKey)> tableColumns;
 
-        public SourceLogic(SqlServerChangeTrackingSource source) : base(source.Shape)
+        public SourceLogic(SqlServerChangeTrackingSource source) : base(source.changeCaptureInterval, source.Shape)
         {
             this.source = source;
             this.sqlConnection = new SqlConnection(this.source.connectionString);
@@ -419,7 +419,7 @@ public class SqlServerChangeTrackingSource : GraphStage<SourceShape<List<DataCel
                 }
 
                 this.GetChanges();
-                this.ScheduleOnce(TimerKey, this.source.changeCaptureInterval);
+                this.ScheduleOnce(TimerKey, this.ChangeCaptureInterval);
             }
             else
             {

--- a/test/Arcane.Framework.Tests.csproj
+++ b/test/Arcane.Framework.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <RootNamespace>Arcane.Framework.Tests</RootNamespace>
     </PropertyGroup>

--- a/test/Sources/CdmChangeFeedSourceTests.cs
+++ b/test/Sources/CdmChangeFeedSourceTests.cs
@@ -280,6 +280,22 @@ namespace Arcane.Framework.Tests.Sources
             Assert.Equal(typeof(string), (schema.Fields.Last() as DataField)!.ClrType);
         }
 
+        [Fact]
+        public void FailsIfChangeCaptureIntervalIsEmpty()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var source = CdmChangeFeedSource.Create(rootPath: "test",
+                    entityName: "ValidEntity",
+                    blobStorage: this.mockBlobStorageService.Object,
+                    isBackfilling: true,
+                    changeCaptureInterval: TimeSpan.FromSeconds(0));
+                Source.FromGraph(source)
+                    .TakeWithin(TimeSpan.FromSeconds(5))
+                    .RunWith(Sink.Seq<List<DataCell>>(), this.akkaFixture.Materializer);
+            });
+        }
+
         private void SetupTableMocks(string entityName)
         {
             this.mockBlobStorageService.Setup(mbs => mbs.ListBlobsAsEnumerable(It.IsAny<string>())).Returns(

--- a/test/Sources/SqlServerChangeTrackingSourceTests.cs
+++ b/test/Sources/SqlServerChangeTrackingSourceTests.cs
@@ -119,9 +119,8 @@ public class SqlServerChangeTrackingSourceTests : IClassFixture<ServiceFixture>,
             .Create(this.connectionString, "dbo", nameof(SqlServerChangeTrackingSourceTests), "test")
             .GetParquetSchema();
 
-        Assert.Equal(6,
-            schema.Fields
-                .Count); // two base columns, SYS_CHANGE_VERSION, SYS_CHANGE_OPERATION, ChangeTrackingVersion and ARCANE_MERGE_KEY
+        // two base columns, SYS_CHANGE_VERSION, SYS_CHANGE_OPERATION, ChangeTrackingVersion and ARCANE_MERGE_KEY
+        Assert.Equal(6, schema.Fields .Count);
     }
 
     [Fact]
@@ -130,7 +129,8 @@ public class SqlServerChangeTrackingSourceTests : IClassFixture<ServiceFixture>,
         Assert.Throws<ArgumentException>(() =>
         {
             var source = SqlServerChangeTrackingSource
-                .Create(this.connectionString, "dbo", nameof(SqlServerChangeTrackingSourceTests), "test");
+                .Create(this.connectionString, "dbo", nameof(SqlServerChangeTrackingSourceTests), "test",
+                    changeCaptureInterval: TimeSpan.FromHours(0));
             Source.FromGraph(source)
                 .TakeWithin(TimeSpan.FromSeconds(5))
                 .RunWith(Sink.Seq<List<DataCell>>(), this.akkaFixture.Materializer);

--- a/test/Sources/SqlServerChangeTrackingSourceTests.cs
+++ b/test/Sources/SqlServerChangeTrackingSourceTests.cs
@@ -125,6 +125,19 @@ public class SqlServerChangeTrackingSourceTests : IClassFixture<ServiceFixture>,
     }
 
     [Fact]
+    public void FailsIfChangeCaptureIntervalIsEmpty()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var source = SqlServerChangeTrackingSource
+                .Create(this.connectionString, "dbo", nameof(SqlServerChangeTrackingSourceTests), "test");
+            Source.FromGraph(source)
+                .TakeWithin(TimeSpan.FromSeconds(5))
+                .RunWith(Sink.Seq<List<DataCell>>(), this.akkaFixture.Materializer);
+        });
+    }
+
+    [Fact]
     public void GetColumns()
     {
         var inputCols = new Dictionary<string, string>


### PR DESCRIPTION
Fixes #61

## Scope

Implemented:
- Created common base class for all source logics that implements polling model for data source.

Additinal changes:
- Bump the framework version to 8.0

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.