### PR TITLE
Match exception by type in decider

### DIFF
--- a/src/Sources/RestApi/RestApiSource.cs
+++ b/src/Sources/RestApi/RestApiSource.cs
@@ -22,7 +22,6 @@ using Arcane.Framework.Sources.RestApi.Services.AuthenticatedMessageProviders;
 using Arcane.Framework.Sources.RestApi.Services.AuthenticatedMessageProviders.Base;
 using Arcane.Framework.Sources.RestApi.Services.UriProviders;
 using Arcane.Framework.Sources.RestApi.Services.UriProviders.Base;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.OpenApi.Models;
 using Parquet.Data;
 using Polly.RateLimit;
@@ -393,6 +392,11 @@ public class RestApiSource : GraphStage<SourceShape<JsonElement>>, IParquetSourc
             }
         }
 
+        protected override void OnTimer(object timerKey)
+        {
+            this.PullChanges();
+        }
+
         private void OnRecordReceived(Task<Option<JsonElement>> readTask)
         {
             if (readTask.IsFaulted || readTask.IsCanceled)
@@ -509,10 +513,5 @@ public class RestApiSource : GraphStage<SourceShape<JsonElement>>, IParquetSourc
             } => Option<JsonElement>.None, // Potential server-side timeout due to overload
             _ => throw exception
         };
-
-        protected override void OnTimer(object timerKey)
-        {
-            this.PullChanges();
-        }
     }
 }

--- a/test/Sources/RestApiSourceTests.cs
+++ b/test/Sources/RestApiSourceTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -15,7 +14,6 @@ using Arcane.Framework.Tests.Fixtures;
 using Microsoft.OpenApi.Models;
 using Moq;
 using Polly;
-using Polly.RateLimit;
 using Xunit;
 
 namespace Arcane.Framework.Tests.Sources;

--- a/test/Sources/RestApiSourceTests.cs
+++ b/test/Sources/RestApiSourceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -14,6 +15,7 @@ using Arcane.Framework.Tests.Fixtures;
 using Microsoft.OpenApi.Models;
 using Moq;
 using Polly;
+using Polly.RateLimit;
 using Xunit;
 
 namespace Arcane.Framework.Tests.Sources;


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-stream-rest-api/issues/69

## Scope

Implemented:
- Match exception by class rather then type name

Additional changes:
- The following refactoring was applied:
1. Anonymous function in TryMap was replaced with the `HandleException` method.
2. Large anonymous function body was extracted to the `SendRequest` method.
3. The `PullChanges` method was split to reduce nesting.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.