### PR TITLE
Remove one more transaction from SQL server change feed

### DIFF
--- a/src/Sources/SqlServer/SqlServerChangeTrackingSource.cs
+++ b/src/Sources/SqlServer/SqlServerChangeTrackingSource.cs
@@ -238,15 +238,14 @@ public class SqlServerChangeTrackingSource : GraphStage<SourceShape<List<DataCel
 
         private long? GetChangeTrackingVersion(long version)
         {
-            using var changeTrackingTran = this.sqlConnection.BeginTransaction(IsolationLevel.ReadCommitted);
             var command = (version == 0) switch
             {
                 true => new SqlCommand(
                     $"SELECT MIN(commit_ts) FROM sys.dm_tran_commit_table WHERE commit_time > '{DateTime.UtcNow.AddSeconds(-1 * this.source.lookBackRange):yyyy-MM-dd HH:mm:ss.fff}'",
-                    this.sqlConnection, changeTrackingTran),
+                    this.sqlConnection),
                 false => new SqlCommand(
                     $"SELECT MIN(commit_ts) FROM sys.dm_tran_commit_table WHERE commit_ts > {version}",
-                    this.sqlConnection, changeTrackingTran)
+                    this.sqlConnection)
             };
 
             this.Log.Debug("Executing {command}", command.CommandText);


### PR DESCRIPTION
Fixes  #118

## Scope

Implemented:
- Remove one more transaction from SQL server change tracking source.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.