### PR TITLE
Refactor StreamContext interface

### DIFF
--- a/src/Services/Base/IStreamContext.cs
+++ b/src/Services/Base/IStreamContext.cs
@@ -26,5 +26,5 @@ public interface IStreamContext
     /// <summary>
     /// Stream metadata that can be used by the stream consumer.
     /// </summary>
-    Option<StreamMetadata> StreamMetadata { get; }
+    Option<StreamMetadata> GetStreamMetadata();
 }

--- a/src/Sinks/Extensions/StreamPartitionExtensions.cs
+++ b/src/Sinks/Extensions/StreamPartitionExtensions.cs
@@ -1,0 +1,25 @@
+using Arcane.Framework.Services.Models;
+using Arcane.Framework.Sinks.Models;
+
+namespace Arcane.Framework.Sinks.Extensions;
+
+/// <summary>
+/// Extension methods for StreamPartition class
+/// </summary>
+public static class StreamPartitionExtensions
+{
+    /// <summary>
+    /// Converts a PartitionsMetadataDefinition to a StreamPartition
+    /// </summary>
+    /// <param name="partition"></param>
+    /// <returns></returns>
+    public static StreamPartition ToStreamPartition(this PartitionsMetadataDefinition partition)
+    {
+        return new StreamPartition
+        {
+            Name = partition.Name,
+            FieldName = partition.FieldName,
+            FieldFormat = partition.FieldFormat
+        };
+    }
+}

--- a/test/Providers/TestCases/TestStreamContext.cs
+++ b/test/Providers/TestCases/TestStreamContext.cs
@@ -9,7 +9,7 @@ public class TestStreamContext : IStreamContext, IStreamContextWriter
     public string StreamId => nameof(StreamId);
     public bool IsBackfilling => false;
     public string StreamKind => nameof(StreamKind);
-    public Option<StreamMetadata> StreamMetadata => Option<StreamMetadata>.None;
+    public Option<StreamMetadata> GetStreamMetadata() => new();
 
     public void SetStreamId(string streamId)
     {


### PR DESCRIPTION
Part of #113

## Scope

Implemented:
- The `StreamMetadata` property was replaced with method. This should fix problems win interfering the property with JSON deserialization of the actual StreamContext in plugin.
- Added the `ToStreamPartition` extension method for plugin code simplicity.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.