### PR TITLE
Exit with code 2 if backfill was interrupted by spot reclaim

### DIFF
--- a/src/Providers/Hosting/HostBuilderExtensions.cs
+++ b/src/Providers/Hosting/HostBuilderExtensions.cs
@@ -184,6 +184,11 @@ public static class HostBuilderExtensions
         {
             var completeTask = runner.RunStream(() => graphBuilder.BuildGraph(context));
             await completeTask;
+            if (context.IsBackfilling && lifetimeService.IsStopRequested)
+            {
+               logger.Information("The stream was stopped during backfilling, retrying...");
+               return ExitCodes.RESTART;
+            }
         }
         catch (Exception e)
         {

--- a/src/Services/Base/IStreamLifetimeService.cs
+++ b/src/Services/Base/IStreamLifetimeService.cs
@@ -14,4 +14,9 @@ public interface IStreamLifetimeService: IDisposable
     /// <param name="posixSignal">POSIX signal</param>
     /// <returns></returns>
     void AddStreamTerminationSignal(PosixSignal posixSignal);
+
+    /// <summary>
+    /// Returns true if a stop request has been made
+    /// </summary>
+    bool IsStopRequested { get; }
 }

--- a/src/Services/StreamLifetimeService.cs
+++ b/src/Services/StreamLifetimeService.cs
@@ -38,9 +38,17 @@ internal class StreamLifetimeService: IStreamLifetimeService
         this.registrations.Add(PosixSignalRegistration.Create(posixSignal, this.StopStream));
     }
 
+    /// <inheritdoc cref="IStreamLifetimeService.IsStopRequested"/>>
+    public bool IsStopRequested { get; private set; }
+
+    /// <summary>
+    /// Stops the stream and sets the stop requested flag.
+    /// </summary>
+    /// <param name="context">Posix signal context</param>
     private void StopStream(PosixSignalContext context)
     {
         context.Cancel = true;
+        this.IsStopRequested = true;
         this.logger.LogInformation("Received a signal {signal}. Stopping the hosted stream and shutting down application", context.Signal);
         this.streamRunnerService.StopStream();
     }

--- a/test/Providers/TestCases/TestStreamContext.cs
+++ b/test/Providers/TestCases/TestStreamContext.cs
@@ -6,8 +6,20 @@ namespace Arcane.Framework.Tests.Providers.TestCases;
 
 public class TestStreamContext : IStreamContext, IStreamContextWriter
 {
+    public TestStreamContext(bool backfilling = false)
+    {
+        this.IsBackfilling = backfilling;
+    }
+
+    public TestStreamContext()
+    {
+        this.IsBackfilling = false;
+    }
+
     public string StreamId => nameof(StreamId);
-    public bool IsBackfilling => false;
+
+    public bool IsBackfilling { get; }
+
     public string StreamKind => nameof(StreamKind);
     public Option<StreamMetadata> GetStreamMetadata() => new();
 


### PR DESCRIPTION
Part of #128

Implemented:
- If stream cancellation was requested and stream is running in backfill mode, it will exit with the `ExitCodes.RESTART` instead of 0.

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.