### PR TITLE
Add interruption token to ParquetSink

### DIFF
--- a/src/Services/Base/IInterruptionToken.cs
+++ b/src/Services/Base/IInterruptionToken.cs
@@ -1,0 +1,12 @@
+namespace Arcane.Framework.Services.Base;
+
+/// <summary>
+/// Provides information about a stream interruption
+/// </summary>
+public interface IInterruptionToken
+{
+    /// <summary>
+    /// Returns true if the stream was interrupted
+    /// </summary>
+    public bool IsInterrupted { get; }
+}

--- a/src/Services/Base/IStreamLifetimeService.cs
+++ b/src/Services/Base/IStreamLifetimeService.cs
@@ -6,7 +6,7 @@ namespace Arcane.Framework.Services.Base;
 /// <summary>
 /// Service to manage the lifetime of a stream runner
 /// </summary>
-public interface IStreamLifetimeService: IDisposable
+public interface IStreamLifetimeService: IDisposable, IInterruptionToken
 {
     /// <summary>
     /// Add a signal to listen for to stop the stream

--- a/src/Services/StreamLifetimeService.cs
+++ b/src/Services/StreamLifetimeService.cs
@@ -41,6 +41,9 @@ internal class StreamLifetimeService: IStreamLifetimeService
     /// <inheritdoc cref="IStreamLifetimeService.IsStopRequested"/>>
     public bool IsStopRequested { get; private set; }
 
+    /// <inheritdoc cref="IStreamLifetimeService.IsStopRequested"/>>
+    public bool IsInterrupted => this.IsStopRequested;
+
     /// <summary>
     /// Stops the stream and sets the stop requested flag.
     /// </summary>


### PR DESCRIPTION
Part of #128

Implemented:
- The ParquetSink now has InterruptionToken as a parameter. It will not save completion token if the stream was interrupted.


## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.